### PR TITLE
Don't normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Don't handle line endings automatically
+* -text


### PR DESCRIPTION
git on Windows, by default, normalizes line endings on checkout by automatically converting LF to CRLF. This was causing the novnc bash and python scripts to fail on execution in bash (the shebang couldn't be parsed).

I fixed my local machine by disabling auto line ending normalization globally in git:
`git config --global core.autocrlf false` (and everyone else should do this too)

This commit will prevent other people from hitting [the issue](https://github.com/solarkennedy/wine-x11-novnc-docker/issues/3) altogether. Note that it does NOT imply all files should be treated as binary. It should only affect line ending normalization (https://stackoverflow.com/a/10017566).