### PR TITLE
Updates components (Wine 5.0, websockify 0.9.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV DISPLAY :0
 
 WORKDIR /root/
 RUN wget -O - https://github.com/novnc/noVNC/archive/v1.1.0.tar.gz | tar -xzv -C /root/ && mv /root/noVNC-1.1.0 /root/novnc && ln -s /root/novnc/vnc_lite.html /root/novnc/index.html
-RUN wget -O - https://github.com/novnc/websockify/archive/v0.8.0.tar.gz | tar -xzv -C /root/ && mv /root/websockify-0.8.0 /root/novnc/utils/websockify
+RUN wget -O - https://github.com/novnc/websockify/archive/v0.9.0.tar.gz | tar -xzv -C /root/ && mv /root/websockify-0.9.0 /root/novnc/utils/websockify
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,14 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 RUN dpkg --add-architecture i386
-RUN apt-get update && apt-get -y install xvfb x11vnc xdotool wget tar supervisor net-tools fluxbox curl gnupg2
-RUN curl https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
-RUN curl https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key |apt-key add -
+RUN apt-get update && apt-get -y install xvfb x11vnc xdotool wget tar supervisor net-tools fluxbox gnupg2
+RUN wget -O - https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
+RUN wget -O - https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key |apt-key add -
 RUN echo 'deb https://dl.winehq.org/wine-builds/ubuntu/ bionic main' |tee /etc/apt/sources.list.d/winehq.list
 RUN echo 'deb https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/ ./' |tee /etc/apt/sources.list.d/wine_suse.list
-RUN apt-get update && apt-get -y  install winehq-stable
+RUN apt-get update && apt-get -y install winehq-stable
+RUN mkdir /opt/wine-stable/share/wine/mono && wget -O - https://dl.winehq.org/wine/wine-mono/4.9.4/wine-mono-bin-4.9.4.tar.gz |tar -xzv -C /opt/wine-stable/share/wine/mono 
+RUN mkdir /opt/wine-stable/share/wine/gecko && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.1-x86.msi https://dl.winehq.org/wine/wine-gecko/2.47.1/wine-gecko-2.47.1-x86.msi && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.1-x86_64.msi https://dl.winehq.org/wine/wine-gecko/2.47.1/wine-gecko-2.47.1-x86_64.msi 
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 ENV WINEPREFIX /root/prefix32

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,12 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 RUN dpkg --add-architecture i386
-RUN apt-get update && apt-get -y install xvfb x11vnc xdotool wget tar supervisor wine32-development net-tools fluxbox
+RUN apt-get update && apt-get -y install xvfb x11vnc xdotool wget tar supervisor net-tools fluxbox curl gnupg2
+RUN curl https://dl.winehq.org/wine-builds/winehq.key | apt-key add -
+RUN curl https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key |apt-key add -
+RUN echo 'deb https://dl.winehq.org/wine-builds/ubuntu/ bionic main' |tee /etc/apt/sources.list.d/winehq.list
+RUN echo 'deb https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/ ./' |tee /etc/apt/sources.list.d/wine_suse.list
+RUN apt-get update && apt-get -y  install winehq-stable
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 ENV WINEPREFIX /root/prefix32

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -9,7 +9,7 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:x11vnc]
-command=/usr/bin/x11vnc
+command=/usr/bin/x11vnc -noxrecord
 autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -23,7 +23,7 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:explorer]
-command=/usr/bin/wine /usr/lib/i386-linux-gnu/wine-development/explorer.exe.so
+command=/opt/wine-stable/bin/wine /opt/wine-stable/lib/wine/explorer.exe
 autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Hello,

This PR update Wine to the lastest stable (5.0) with packages from WineHQ (currently via the OpenSUSE building service due to FAudio).

Since these packages doesn't contain wine-gecko & wine-mono, this manually install them.
The user doesn't get a prompt requesting their installation.

This also implement a workaround for a crash in x11vnc.

Best regards,
Nicolas SAPA