### PR TITLE
Update versions, add VNC password, improve GitHub Actions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+template: |
+  ## What’s Changed
+  $CHANGES

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,8 @@ name: Docker Image CI
 on:
   push:
     branches: [ "master" ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
     branches: [ "master" ]
 
@@ -13,6 +15,39 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
     - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+
+    - name: Show informations about this GitHub Event
+      run: echo "$GIT_JSON_DATA"
+      env:
+        GIT_JSON_DATA: ${{ toJson(github) }}
+
+    - name: "[TAG] Detect Variables"
+      if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
+      run: |
+        echo COMMIT_SHA_SHORT="$( echo ${{ github.sha }} | cut -c1-7 )" >> $GITHUB_ENV
+        echo DOCKER_IMAGE_TAG="$( echo ${{ github.event.ref }} | sed -e 's|^refs/tags/||g' | grep -E '^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' )" >> $GITHUB_ENV
+
+    - name: "[OTHER] Detect Variables"
+      if: ${{ github.event_name != 'push' || github.ref_type != 'tag' }}
+      run: |
+        echo COMMIT_SHA_SHORT="$( echo ${{ github.sha }} | cut -c1-7 )" >> $GITHUB_ENV
+        echo DOCKER_IMAGE_TAG="$( echo ${{ github.sha }} | cut -c1-7 )" >> $GITHUB_ENV
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+    - name: Build and Push the Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: |
+          ${{ secrets.DOCKER_HUB_USER }}/wine-x11-novnc-docker:${{ env.COMMIT_SHA_SHORT }}
+          ${{ secrets.DOCKER_HUB_USER }}/wine-x11-novnc-docker:${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,14 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN dpkg --add-architecture i386 && \
     mkdir /opt/wine-stable/share/wine/gecko && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.2-x86.msi https://dl.winehq.org/wine/wine-gecko/2.47.2/wine-gecko-2.47.2-x86.msi && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.2-x86_64.msi https://dl.winehq.org/wine/wine-gecko/2.47.2/wine-gecko-2.47.2-x86_64.msi && \
     apt-get -y full-upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+ADD supervisord-wine.conf /etc/supervisor/conf.d/supervisord-wine.conf
 
 ENV WINEPREFIX /root/prefix32
 ENV WINEARCH win32

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,22 +7,24 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 RUN dpkg --add-architecture i386 && \
-    apt-get update && apt-get -y install python2 python-is-python2 xvfb x11vnc xdotool wget tar supervisor net-tools fluxbox gnupg2 && \
-    wget -O - https://dl.winehq.org/wine-builds/winehq.key | apt-key add -  && \
-    echo 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' |tee /etc/apt/sources.list.d/winehq.list && \
-    apt-get update && apt-get -y install winehq-stable=7.0.0.0~focal-1  && \
+    apt-get update && apt-get -y install python3 python-is-python3 xvfb x11vnc xdotool wget tar supervisor net-tools fluxbox gnupg2 && \
+    echo 'echo -n $HOSTNAME' > /root/x11vnc_password.sh && chmod +x /root/x11vnc_password.sh && \
+    wget -O - https://dl.winehq.org/wine-builds/winehq.key | apt-key add - && \
+    echo 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' | tee /etc/apt/sources.list.d/winehq.list && \
+    apt-get update && apt-get -y install winehq-stable=7.0.1~focal-1 && \
     mkdir /opt/wine-stable/share/wine/mono && wget -O - https://dl.winehq.org/wine/wine-mono/7.0.0/wine-mono-7.0.0-x86.tar.xz | tar -xJv -C /opt/wine-stable/share/wine/mono && \
-    mkdir /opt/wine-stable/share/wine/gecko && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.1-x86.msi https://dl.winehq.org/wine/wine-gecko/2.47.1/wine-gecko-2.47.1-x86.msi && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.1-x86_64.msi https://dl.winehq.org/wine/wine-gecko/2.47.1/wine-gecko-2.47.1-x86_64.msi && \
+    mkdir /opt/wine-stable/share/wine/gecko && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.3-x86.msi https://dl.winehq.org/wine/wine-gecko/2.47.3/wine-gecko-2.47.3-x86.msi && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.3-x86_64.msi https://dl.winehq.org/wine/wine-gecko/2.47.3/wine-gecko-2.47.3-x86_64.msi && \
     apt-get -y full-upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+#ADD x11vnc_password.sh /root/x11vnc_password.sh
 
 ENV WINEPREFIX /root/prefix32
 ENV WINEARCH win32
 ENV DISPLAY :0
 
 WORKDIR /root/
-RUN wget -O - https://github.com/novnc/noVNC/archive/v1.1.0.tar.gz | tar -xzv -C /root/ && mv /root/noVNC-1.1.0 /root/novnc && ln -s /root/novnc/vnc_lite.html /root/novnc/index.html && \
-    wget -O - https://github.com/novnc/websockify/archive/v0.9.0.tar.gz | tar -xzv -C /root/ && mv /root/websockify-0.9.0 /root/novnc/utils/websockify
+RUN wget -O - https://github.com/novnc/noVNC/archive/v1.3.0.tar.gz | tar -xzv -C /root/ && mv /root/noVNC-1.3.0 /root/novnc && ln -s /root/novnc/vnc_lite.html /root/novnc/index.html && \
+    wget -O - https://github.com/novnc/websockify/archive/v0.11.0.tar.gz | tar -xzv -C /root/ && mv /root/websockify-0.11.0 /root/novnc/utils/websockify
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN dpkg --add-architecture i386 && \
     mkdir /opt/wine-stable/share/wine/gecko && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.3-x86.msi https://dl.winehq.org/wine/wine-gecko/2.47.3/wine-gecko-2.47.3-x86.msi && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.3-x86_64.msi https://dl.winehq.org/wine/wine-gecko/2.47.3/wine-gecko-2.47.3-x86_64.msi && \
     apt-get -y full-upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-#ADD x11vnc_password.sh /root/x11vnc_password.sh
 
 ENV WINEPREFIX /root/prefix32
 ENV WINEARCH win32

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN dpkg --add-architecture i386 && \
     echo 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main' | tee /etc/apt/sources.list.d/winehq.list && \
     apt-get update && apt-get -y install winehq-stable=7.0.1~focal-1 && \
     mkdir /opt/wine-stable/share/wine/mono && wget -O - https://dl.winehq.org/wine/wine-mono/7.0.0/wine-mono-7.0.0-x86.tar.xz | tar -xJv -C /opt/wine-stable/share/wine/mono && \
-    mkdir /opt/wine-stable/share/wine/gecko && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.3-x86.msi https://dl.winehq.org/wine/wine-gecko/2.47.3/wine-gecko-2.47.3-x86.msi && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.3-x86_64.msi https://dl.winehq.org/wine/wine-gecko/2.47.3/wine-gecko-2.47.3-x86_64.msi && \
+    mkdir /opt/wine-stable/share/wine/gecko && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.2-x86.msi https://dl.winehq.org/wine/wine-gecko/2.47.2/wine-gecko-2.47.2-x86.msi && wget -O /opt/wine-stable/share/wine/gecko/wine-gecko-2.47.2-x86_64.msi https://dl.winehq.org/wine/wine-gecko/2.47.2/wine-gecko-2.47.2-x86_64.msi && \
     apt-get -y full-upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,23 @@ on the Docker Hub.
 
 ## Run It
 
+    # Start the container
     docker run --rm -p 8080:8080 solarkennedy/wine-x11-novnc-docker
+
+    # Show the container ID (this is the VNC password)
+    docker ps
+
+    # Open VNC in your web browser
     xdg-open http://localhost:8080
 
-In your web browser you should see the default application, explorer.exe:
+
+In your web browser, type the container ID as password, and then you should see the default application, explorer.exe:
 
 ![Explorer Screenshot](https://raw.githubusercontent.com/solarkennedy/wine-x11-novnc-docker/master/screenshot.png)
 
 ## Modifying
 
-This is a base image. You should fork or use this base image to run your own
-wine programs?
+This is a base image. You should fork or use this base image to run your own wine programs?
 
 ## Issues
 

--- a/supervisord-wine.conf
+++ b/supervisord-wine.conf
@@ -1,0 +1,6 @@
+[program:explorer]
+command=/opt/wine-stable/bin/wine /opt/wine-stable/lib/wine/i386-windows/explorer.exe
+autorestart=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -22,13 +22,6 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
-[program:explorer]
-command=/opt/wine-stable/bin/wine /opt/wine-stable/lib/wine/i386-windows/explorer.exe
-autorestart=true
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-redirect_stderr=true
-
 [program:fluxbox]
 command=/usr/bin/fluxbox
 autorestart=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -9,21 +9,21 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:x11vnc]
-command=/usr/bin/x11vnc -noxrecord
+command=/usr/bin/x11vnc -noxrecord -usepw -passwdfile cmd:/root/x11vnc_password.sh
 autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:novnc]
-command=/root/novnc/utils/launch.sh --vnc localhost:5900 --listen 8080
+command=/root/novnc/utils/novnc_proxy --vnc localhost:5900 --listen 8080
 autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
 
 [program:explorer]
-command=/opt/wine-stable/bin/wine /opt/wine-stable/lib/wine/explorer.exe
+command=/opt/wine-stable/bin/wine /opt/wine-stable/lib/wine/i386-windows/explorer.exe
 autorestart=true
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0

--- a/x11vnc_password.sh
+++ b/x11vnc_password.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo -n $HOSTNAME

--- a/x11vnc_password.sh
+++ b/x11vnc_password.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-echo -n $HOSTNAME


### PR DESCRIPTION
This PR adds the following improvements:

- Update versions:
  - `winehq-stable` updated from `v7.0.0.0~focal-1` updated to `v7.0.1~focal-1`
  - `wine-gecko` updated from `v2.47.1` to `v2.47.2`
  - `novnc` updated from `v1.1.0` to `v1.3.0`
  - `websockify` updated from `v0.9.0` to `v0.11.0`
  - `python` updated from `v2.x` to `v3.x` (required for `websockify` starting `v0.10.0`)

- Fix `novnc` and `explorer` commands according to version update

- Add script `/root/x11vnc_password.sh` that uses the Container ID as `x11vnc` password by default
  - If needed, this script can be overwritten with the `-v <custom_script>:/root/x11vnc_password.sh` which allows to provide custom passwords
  
- Move the `supervisord` configuration block for `wine` into a separate file so we can easily override it with the real program we want to run with `wine`

- Add Release Drafter to show nice changes between versions

- Improve GitHub Actions script:
  - Allow to specify the DockerHub repo to push the images to
  - Tag the images with the `commit ID`, and with the Tag `vX.Y.Z` if detected